### PR TITLE
No need to install the package on jenkins build machine

### DIFF
--- a/git-openssl.sh
+++ b/git-openssl.sh
@@ -35,5 +35,5 @@ fi
 # Build it.
 dpkg-buildpackage -rfakeroot -b
 
-# Install
-find .. -type f -name "git_*ubuntu*.deb" -exec sudo dpkg -i \{\} \;
+# Store for artifact pick up
+find .. -type f -name "git_*ubuntu*.deb" -exec cp -i {} ./ \;


### PR DESCRIPTION
Don't need to install the package on machine since we kill/terminate off the machine after a certain amount of time. 